### PR TITLE
Fix rm warning

### DIFF
--- a/tasks/destroy_chef_solo_materials.yml
+++ b/tasks/destroy_chef_solo_materials.yml
@@ -4,5 +4,7 @@
 ######
 
 - name: Destroy chef-solo tmp files
-  shell: "rm -rf {{ chef_solo_runner_solo_path }}/*"
+  file:
+    state: abstent
+    path: "{{ chef_solo_runner_solo_path }}"
   when: chef_solo_runner_destroy_solo_materials|bool

--- a/tasks/destroy_chef_solo_materials.yml
+++ b/tasks/destroy_chef_solo_materials.yml
@@ -5,6 +5,7 @@
 
 - name: Destroy chef-solo tmp files
   file:
-    state: abstent
-    path: "{{ chef_solo_runner_solo_path }}"
+    state: absent
+    force: yes
+    path: "{{ chef_solo_runner_solo_path }}/*"
   when: chef_solo_runner_destroy_solo_materials|bool


### PR DESCRIPTION
Update syntax to use file module instead of shell commands.
Use the force flag

The reason why the force flag might be needed, is because some files are being created with root user by some reason that I haven't figured out yet.